### PR TITLE
Changed name of Error class to make it compatible with PHP 7

### DIFF
--- a/classes/class.error.php
+++ b/classes/class.error.php
@@ -6,7 +6,7 @@
  * @copyright  2015
  * @license    Public Domain
  */ 
-class Error {
+class Error_ {
     
     private $errors = array();
     

--- a/init.php
+++ b/init.php
@@ -82,7 +82,7 @@ foreach($config['asset'] as $asset_id => $conf)
     }
 }
 
-$error = new Error();
+$error = new Error_();
 
 // Logout user
 if(isset($_POST['logout']) AND csrf_check($_POST['csrf_token'])) 


### PR DESCRIPTION
PHP 7 reserves the class name "Error" so the **Error** class in these files needed to be changed. An underscore was appended to the **Error** class so that it now is **Error_** 

This is only needed for PHP versions >= 7.0. Previous versions will work with either **Error** or **Error_**